### PR TITLE
#5 Minimal parser

### DIFF
--- a/playground.fsx
+++ b/playground.fsx
@@ -12,6 +12,19 @@ let testPath = Path.Combine(__SOURCE_DIRECTORY__,  "./../../nfdi4plants/arc-vali
 
 let testOntology = OboOntology.fromFile true testPath
 
+let testTerms = [
+    OboTerm.Create("test:000", Name = "test0")
+    OboTerm.Create("test:001", Name = "test1a", IsA = ["test:000"])
+    OboTerm.Create("test:002", Name = "test2", IsA = ["test:001"])
+    OboTerm.Create("test:003", Name = "test1b", IsA = ["test:000"])
+]
+
+let testOntology = OboOntology.create testTerms []
+
+testOntology.GetChildOntologyAnnotations(testTerms.Head.Id)
+testOntology.GetChildOntologyAnnotations(testTerms.Head.Id, Depth = 1)
+testOntology.GetChildOntologyAnnotations(testTerms.Head.Id, Depth = 2)
+
 //let fileLines = File.ReadAllLines testPath
 
 //OboTerm.fromLines true ((fileLines |> Seq.ofArray).GetEnumerator()) 0

--- a/src/FsOboParser/FsOboParser.fsproj
+++ b/src/FsOboParser/FsOboParser.fsproj
@@ -17,6 +17,7 @@
     <Compile Include="TermSynonym.fs" />
     <Compile Include="OboTerm.fs" />
     <Compile Include="OboTypeDef.fs" />
+    <Compile Include="OboEntry.fs" />
     <Compile Include="OboOntology.fs" />
     <Compile Include="FastOboGraph.fs" />
   </ItemGroup>
@@ -35,7 +36,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.1.1" PrivateAssets="All"/>
+    <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.1.1" PrivateAssets="All" />
     <PackageReference Include="ISADotNet" Version="0.6.1" />
   </ItemGroup>
 

--- a/src/FsOboParser/OboEntry.fs
+++ b/src/FsOboParser/OboEntry.fs
@@ -1,0 +1,7 @@
+﻿namespace FsOboParser
+
+
+/// Model of raw OboEntries, divided into Terms (as `OboTerm`s) and TypeDefs (as `OboTypeDef`s).
+type OboEntry =
+    | Term of OboTerm
+    | TypeDef of OboTypeDef

--- a/src/FsOboParser/OboTypeDef.fs
+++ b/src/FsOboParser/OboTypeDef.fs
@@ -5,7 +5,7 @@ open DBXref
 open System
 
 
-/// Models the relationship between OBO Terms 
+/// Models the relationship between OBO Terms.
 type OboTypeDef = 
     {
         ///The unique id of the current term. 


### PR DESCRIPTION
This PR
- adds Discriminated Union type `OboEntry`
- adds functionality to read OBO files and parse them as a list of OboEntries
  - incorporates this functionality into existing OboOntology functions