### PR TITLE
TermRelations and their getters

### DIFF
--- a/playground.fsx
+++ b/playground.fsx
@@ -9,23 +9,29 @@ open FsOboParser
 open System.IO
 
 
-let testPath = Path.Combine(__SOURCE_DIRECTORY__,  "./../../nfdi4plants/arc-validate/ErrorClassOntology.obo")
+//let testPath = Path.Combine(__SOURCE_DIRECTORY__,  "./../../nfdi4plants/arc-validate/ErrorClassOntology.obo")
 
 //OboEntries.fromFile true testPath
-let testOntology = OboOntology.fromFile true testPath
+//let testOntology = OboOntology.fromFile true testPath
 
 let testTerms = [
     OboTerm.Create("test:000", Name = "test0")
     OboTerm.Create("test:001", Name = "test1a", IsA = ["test:000"])
-    OboTerm.Create("test:002", Name = "test2", IsA = ["test:001"])
+    OboTerm.Create("test:002", Name = "test2", IsA = ["test:001"; "test:000"])
     OboTerm.Create("test:003", Name = "test1b", IsA = ["test:000"])
 ]
 
 let testOntology = OboOntology.create testTerms []
 
+
+OboOntology.getRelations testOntology
+
+
 testOntology.GetChildOntologyAnnotations(testTerms.Head.Id)
 testOntology.GetChildOntologyAnnotations(testTerms.Head.Id, Depth = 1)
 testOntology.GetChildOntologyAnnotations(testTerms.Head.Id, Depth = 2)
+
+
 
 let performanceTerms = List.init 7000000 (fun i -> OboTerm.Create($"lol:{i}"))
 let performanceOboOntology = OboOntology.create performanceTerms []

--- a/src/FsOboParser/OboTerm.fs
+++ b/src/FsOboParser/OboTerm.fs
@@ -539,3 +539,13 @@ type OboTerm =
     /// Takes an OboTerm and returns its relationships as a triple consisting of the input term's ID, the name of the relationship, and the related term's ID.
     static member getRelatedTermIds (term : OboTerm) =
         term.GetRelatedTermIds()
+
+
+/// Representation of a the relation an OboTerm can have with other OboTerms.
+type TermRelation<'a> =
+    /// No Relation with other OboTerms.
+    | Empty of SourceTerm : OboTerm
+    /// Relation between one OboTerm with another in the form of generic relation `'a` * source OboTerm * target OboTerm.
+    | Target of Relation :'a * SourceTerm : OboTerm * TargetTerm : OboTerm
+    /// Relation between one OboTerm with another OboTerm that is not defined in the OboOntology in the form of generic relation `'a` * source OboTerm.
+    | TargetMissing of Relation :'a * SourceTerm : OboTerm

--- a/tests/FsOboParser.Tests/OboOntology.Tests.fs
+++ b/tests/FsOboParser.Tests/OboOntology.Tests.fs
@@ -9,14 +9,56 @@ module OboOntologyTests =
     [<Tests>]
     let oboOntologyTest =
         testList "OboOntology" [
-            let testTerm1 = OboTerm.Create("id:1", Name = "testTerm1", Relationships = ["related_to id:2"; "unrelated_to id:3"; "antirelated_to id:4"])
-            let testTerm2 = OboTerm.Create("id:2", Name = "testTerm2", Relationships = ["related_to id:1"])
-            let testTerm3 = OboTerm.Create("id:3", Name = "testTerm3", Relationships = ["unrelated_to id:1"])
-            let testOntology = OboOntology.create [testTerm1; testTerm2; testTerm3] []
+            let testTerm1 = 
+                OboTerm.Create(
+                    "id:1", 
+                    Name = "testTerm1", 
+                    Relationships = ["related_to id:2"; "unrelated_to id:3"; "antirelated_to id:4"]
+                )
+            let testTerm2 = 
+                OboTerm.Create(
+                    "id:2", 
+                    Name = "testTerm2", 
+                    Relationships = ["related_to id:1"]
+                )
+            let testTerm3 = 
+                OboTerm.Create(
+                    "id:3", 
+                    Name = "testTerm3", 
+                    Relationships = ["unrelated_to id:1"],
+                    IsA = ["id:1"; "id:2"]
+                )
+            let testTerm4 =
+                OboTerm.Create(
+                    "id:5",
+                    Name = "testTerm4"
+                )
+            let testOntology = OboOntology.create [testTerm1; testTerm2; testTerm3; testTerm4] []
             testList "GetRelatedTerms" [
                 testCase "returns correct related terms" <| fun _ ->
                     let actual = testOntology.GetRelatedTerms(testTerm1)
                     let expected = [testTerm1, "related_to", Some testTerm2; testTerm1, "unrelated_to", Some testTerm3; testTerm1, "antirelated_to", None]
+                    Expect.sequenceEqual actual expected "is not equal"
+            ]
+            testList "GetIsAs" [
+                testCase "returns correct related terms" <| fun _ ->
+                    let actual = testOntology.GetIsAs testTerm3
+                    let expected = [testTerm3, Some testTerm1; testTerm3, Some testTerm2]
+                    Expect.sequenceEqual actual expected "is not equal"
+            ]
+            testList "GetRelations" [
+                testCase "returns correct TermRelations" <| fun _ ->
+                    let actual = testOntology.GetRelations()
+                    let expected = [
+                        Target ("related_to", testTerm1, testTerm2)
+                        Target ("unrelated_to", testTerm1, testTerm3)
+                        TargetMissing ("antirelated_to", testTerm1)
+                        Target ("related_to", testTerm2, testTerm1)
+                        Target ("unrelated_to", testTerm3, testTerm1)
+                        Target ("is_a", testTerm3, testTerm1)
+                        Target ("is_a", testTerm3, testTerm2)
+                        Empty testTerm4
+                    ]
                     Expect.sequenceEqual actual expected "is not equal"
             ]
         ]


### PR DESCRIPTION
This PR
- adds
  - type `TermRelations`
  - functions to get such
  - functions to get `is_a` relations
  - unit tests for everything above
- closes #14