### PR TITLE
Synonym function output type

### DIFF
--- a/src/FsOboParser/OboOntology.fs
+++ b/src/FsOboParser/OboOntology.fs
@@ -344,6 +344,7 @@ type OboOntology =
         |> Seq.map (
             fun s -> 
                 s.Scope,
+                term,
                 this.Terms 
                 |> Seq.tryFind (
                     fun t -> 
@@ -367,7 +368,7 @@ type OboOntology =
                             t.Name = String.replace "\"" "" s.Text
                     )
                 match sto with
-                | Some st -> Some (s.Scope, st)
+                | Some st -> Some (s.Scope, term, st)
                 | None -> None
         )
 

--- a/tests/FsOboParser.Tests/OboOntology.Tests.fs
+++ b/tests/FsOboParser.Tests/OboOntology.Tests.fs
@@ -71,13 +71,13 @@ module OboOntologyTests =
             testList "GetSynonyms" [
                 testCase "returns correct synonymous terms" <| fun _ ->
                     let actual = testOntology.GetSynonyms testTerm5
-                    let expected = seq {Exact, testTerm1; Broad, testTerm2}
+                    let expected = seq {Exact, testTerm5, testTerm1; Broad, testTerm5, testTerm2}
                     Expect.sequenceEqual actual expected "is not equal"
             ]
             testList "TryGetSynonyms" [
                 testCase "returns correct synonymous terms" <| fun _ ->
                     let actual = testOntology.TryGetSynonyms testTerm5
-                    let expected = seq {Exact, Some testTerm1; Broad, Some testTerm2; Narrow, None}
+                    let expected = seq {Exact, testTerm5, Some testTerm1; Broad, testTerm5, Some testTerm2; Narrow, testTerm5, None}
                     Expect.sequenceEqual actual expected "is not equal"
             ]
         ]


### PR DESCRIPTION
This PR
- changes the output type of synonym functions
  - to be more in line with e.g. `getRelations` function
- closes #21